### PR TITLE
feat(config): add single vm config deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 judgels
+.serena

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Simplified judgels deployment with docker compose without using the official ans
 
 ## ⚙️ How to use
 
-This docker-compose configuration requires you to prepare 1 core VM and $N$ grader VM. 
+This docker-compose configuration supports two deployment topologies:
+
+- **Multi-VM** (recommended for production): 1 core VM + $N$ grader VMs. Graders fetch problem data from the core VM over SSH. Gives you resource isolation between the core services and the untrusted user code that graders sandbox. The steps below cover this setup.
+- **Single-VM**: everything runs on one host. Graders read problem data via a local bind mount instead of SSH. Simpler to set up, but grader sandboxes share the host with the core DB/API — a sandbox escape has a larger blast radius. See [Single-VM deployment](#single-vm-deployment).
+
+For multi-VM:
 
 - Core VM will be used to host the React Client, Java Server, MySQL Database and RabbitMQ Message Broker that can be spin up with containers defined in [docker-compose.yml](./docker-compose.yml). 
 - The Grader VM is used to run the grading system. You can also run the grader on your local machine, as long as it has the SSH private key that corresponds to the Grader VM’s public key. The Grader VM’s **SSH public key must be added to the Core VM’s `authorized_keys`** to allow SSH access. You can start the grader container using the `spawn-grader.sh` script.
@@ -68,6 +73,43 @@ sudo ./spawn-grader.sh
 ```
 
 10. And that's all, you're good to go. You can access the web client interface (User and Admin for creating contests) at `CORE_VM_IP`, and the web admin interface (Admin for managing problemsets) at `CORE_VM_IP:9101`, depending on the ports defined in the judgels-server container of your [docker-compose.yml](./docker-compose.yml). To create a contest, log in as superadmin through the web client interface.
+
+## Single-VM deployment
+
+Runs the core services and graders on the same host. Use this for local development, small deployments, or when you don't need the isolation boundary that multi-VM provides.
+
+> [!WARNING]
+> Grader sandboxes will share the host with the core DB, API, and RabbitMQ. A sandbox escape from untrusted user code has a larger blast radius than in the multi-VM setup. Prefer multi-VM for production.
+
+From the core VM, **after completing steps 1–5 from the multi-VM instructions above**:
+
+1. Provision the host for the grader sandbox (kernel tuning, reboots at the end):
+
+```zsh
+chmod +x ./prov-grader.sh
+sudo ./prov-grader.sh
+```
+
+2. Edit [./conf/judgels-grader.yml](./conf/judgels-grader.yml) and set:
+
+```yaml
+gabriel:
+  cache:
+    serverBaseDataDir: /judgels/server/var/data
+```
+
+No `user@host:` prefix. This is the path **inside the grader container** where the server data directory will be bind-mounted read-only. `rsyncIdentityFile` can be left at its default since rsync ignores the SSH transport when both source and destination are local paths.
+
+3. Spawn the grader containers on the same host:
+
+```zsh
+chmod +x ./spawn-grader.sh
+sudo ./spawn-grader.sh
+```
+
+The script detects the running `judgels-server` container and bind-mounts `./judgels/server/var/data` into each grader. No SSH keypair, no `authorized_keys` entry, and no separate Grader VM are needed.
+
+4. Access the interfaces as described in the multi-VM step 10, except `CORE_VM_IP` is your single host's address (use `localhost` if accessing from the same machine).
 
 ## Contributing
 

--- a/conf/judgels-grader.yml
+++ b/conf/judgels-grader.yml
@@ -29,7 +29,10 @@ gabriel:
 
   cache:
     cachedBaseDataDir: var/data
-    serverBaseDataDir: user@localhost:/opt/judgels/server/var/data   # CHANGE THIS TO VALID CORE VM SSH CREDENTIAL AND CORE VM DIRECTORY
+    # CHANGE THIS TO VALID CORE VM SSH CREDENTIAL AND CORE VM DIRECTORY
+    # If you are running the grader on core vm (1 vm setup), just change this to absolute path dir of the mounted container dir
+    # e.g: /judgels/server/var/data
+    serverBaseDataDir: user@localhost:/opt/judgels/server/var/data   
     rsyncIdentityFile: var/conf/judgels-grader
 
   isolate:

--- a/core-deploy.sh
+++ b/core-deploy.sh
@@ -45,5 +45,7 @@ docker run --rm \
     "ghcr.io/ia-toki/judgels/server:${IMAGE_VERSION}" \
     db migrate
 
+docker start judgels-server # attempt to restart judgels server on db migration success
+
 echo "Judgels database migration success!";
 echo "Judgels server is already running! Visit at http://{ip_address} for user interface and http://{ip_address}:9101 for admin interface";

--- a/sample/boxes-of-apple.cpp
+++ b/sample/boxes-of-apple.cpp
@@ -1,0 +1,16 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int main() {
+    int n;
+    long long sum = 0;
+    cin >> n;
+    for(int i = 0; i < n; i++) {
+        long long x;
+        cin >> x;
+        sum += x;
+    }
+    cout << sum << endl;
+    return 0;
+}

--- a/spawn-grader.sh
+++ b/spawn-grader.sh
@@ -2,6 +2,7 @@
 
 NUM_OF_GRADERS=2
 IMAGE_VERSION="${JUDGELS_VERSION:-2.22.0}"
+COMPOSE_NETWORK=judgels-compose_judgels-net
 
 for(( i=0; i<NUM_OF_GRADERS; i++ ))
 do
@@ -10,8 +11,10 @@ do
     docker run -d \
         --name judgels-grader-$i \
         --privileged \
+        --network $COMPOSE_NETWORK \
         -v ./judgels/grader-$i/var:/judgels/grader/var \
         -v ./conf/judgels-grader.yml:/judgels/grader/var/conf/judgels-grader.yml \
+        -v ./judgels/server/var/data:/judgels/server/var/data:ro \
         --health-cmd="pgrep -f judgels || exit 1" \
         --restart on-failure:3 \
         --log-driver json-file \

--- a/spawn-grader.sh
+++ b/spawn-grader.sh
@@ -4,9 +4,37 @@ NUM_OF_GRADERS=2
 IMAGE_VERSION="${JUDGELS_VERSION:-2.22.0}"
 COMPOSE_NETWORK=judgels-compose_judgels-net
 
+if docker ps -a --format '{{.Names}}' | grep -q '^judgels-server$'; then
+    SAME_HOST=true
+    echo "Detected judgels-server on this host. Same-VM deployment."
+    echo "Server data will be bind-mounted into graders (no SSH needed)."
+    echo "Ensure conf/judgels-grader.yml has:"
+    echo "    serverBaseDataDir: /judgels/server/var/data"
+else
+    SAME_HOST=false
+    echo "No judgels-server container found. Assuming separate-VM deployment."
+    echo "Graders will fetch problem data over SSH."
+    echo "Ensure conf/judgels-grader.yml has:"
+    echo "    serverBaseDataDir: <user>@<core-vm>:/path/to/server/var/data"
+    echo "    rsyncIdentityFile: var/conf/judgels-grader"
+    echo "And that the SSH private key is placed at ./judgels/grader-<N>/var/conf/judgels-grader."
+fi
+
+read -p "Continue spawning $NUM_OF_GRADERS grader(s)? [y/N] " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
 for(( i=0; i<NUM_OF_GRADERS; i++ ))
 do
     echo "Creating judgels-grader-$i container....";
+
+    DATA_MOUNT=()
+    if [[ "$SAME_HOST" == "true" ]]; then
+        DATA_MOUNT=(-v ./judgels/server/var/data:/judgels/server/var/data:ro)
+    fi
 
     docker run -d \
         --name judgels-grader-$i \
@@ -14,7 +42,7 @@ do
         --network $COMPOSE_NETWORK \
         -v ./judgels/grader-$i/var:/judgels/grader/var \
         -v ./conf/judgels-grader.yml:/judgels/grader/var/conf/judgels-grader.yml \
-        -v ./judgels/server/var/data:/judgels/server/var/data:ro \
+        "${DATA_MOUNT[@]}" \
         --health-cmd="pgrep -f judgels || exit 1" \
         --restart on-failure:3 \
         --log-driver json-file \
@@ -24,4 +52,4 @@ do
         "ghcr.io/ia-toki/judgels/grader:${IMAGE_VERSION}"
 
     echo "judgels-grader-$i container created....";
-done 
+done


### PR DESCRIPTION
## Summary

Added support for running judgels-compose with the grader located inside the same core VM. 

## Changes

### `spawn-grader.sh`
- Detects whether `judgels-server` is running on this Docker host via `docker ps -a`.
- Prints deployment-mode-specific guidance (which fields in `judgels-grader.yml` to set) and prompts the user to confirm before spawning.
- Conditionally bind-mounts `./judgels/server/var/data` read-only into each grader at `/judgels/server/var/data` when same-host is detected. Skipped when separate-VM, rsync-over-SSH will handle the transport as before.

### `conf/judgels-grader.yml`
- Kept the SSH-style default for `serverBaseDataDir` to preserve multi-VM behaviour.
- Expanded the inline comment to document the single-VM form (`/judgels/server/var/data`, matching the new bind-mount target).

### `core-deploy.sh`
- Added `docker start judgels-server` after the DB migration step so the server comes back up on a fresh deploy.

## Architecture notes

The trade-off is security and isolation. Running the grader on the same VM **is not recommended** on production scale (e.g: host national competition) as it risks exposing the data to any participant capable of escaping grader's sandbox. Another risk is resource contention, during peak submission bursts, grader CPU and memory usage can starve the core server and degrade the experience of every participatns. For any high stakes event, **always prefer multi vm setup**

| Aspect | Single-VM | Multi-VM |
| --- | --- | --- |
| SSH keypair setup | Not needed | Required |
| Disk usage | Bind mount (no duplication beyond grader cache) | Full copy per grader VM |
| Sandbox escape blast radius | Reaches core DB/API on same host | Contained to grader VM |
| Horizontal scaling of graders | Limited to one host | Native |

## Test plan

- [x] Run `./spawn-grader.sh` on the same host; confirm output reads "Detected judgels-server on this host" and the prompt appears.
- [x] Accept prompt; confirm both graders start: `docker ps --filter name=judgels-grader`.
- [x] `docker exec judgels-grader-0 ls /judgels/server/var/data` should list `problems/`, `submissions/`, etc.
- [x] Submit `sample/boxes-of-apple.cpp` to a problem via the web admin UI. Confirm the status should be AC
